### PR TITLE
docs: update RegVelo reference to published Cell paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Almost all are part of the [scverse ecosystem].
 | [moscot] | Optimal transport for temporal, spatial, and spatio-temporal single-cell mapping | [Klein et al. (2025)] |
 | [moslin] | Trajectory inference with lineage barcodes via optimal transport (part of moscot) | [Lange et al. (2024)] |
 | [VeloVI] | RNA velocity with variational inference and uncertainty quantification (part of scvi-tools) | [Gayoso et al. (2024)] |
-| [RegVelo] | Jointly learning gene regulation and RNA velocity | [Wang et al. (2024)] |
+| [RegVelo] | Jointly learning gene regulation and RNA velocity | [Wang et al. (2026)] |
 | [CellMapper] | kNN-based label, embedding, and molecular layer transfer between datasets | — |
 | [CellAnnotator] | LLM-based cell type annotation with support for major LLM providers | — |
 
@@ -67,7 +67,7 @@ Almost all are part of the [scverse ecosystem].
 [Klein et al. (2025)]: https://doi.org/10.1038/s41586-024-08453-2
 [Lange et al. (2024)]: https://doi.org/10.1186/s13059-024-03422-4
 [Gayoso et al. (2024)]: https://doi.org/10.1038/s41592-023-01994-w
-[Wang et al. (2024)]: https://doi.org/10.1101/2024.12.11.627935
+[Wang et al. (2026)]: https://www.cell.com/cell/fulltext/S0092-8674(26)00457-5
 
 [La Manno et al. (2018)]: https://doi.org/10.1038/s41586-018-0414-6
 [Bergen et al. (2020)]: https://doi.org/10.1038/s41587-020-0591-3


### PR DESCRIPTION
## Change RegVelo reference
- RegVelo's citation in the ecosystem table pointed to the bioRxiv preprint (Wang et al., 2024). The paper is now published in Cell, so this updates the reference to the final version.
- Updated `[Wang et al. (2024)]` → `[Wang et al. (2026)]`, and the link from `https://doi.org/10.1101/2024.12.11.627935` to `https://www.cell.com/cell/fulltext/S0092-8674(26)00457-5`.